### PR TITLE
[feat] 화면 라우팅 구성하기

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ src/
 ├── pages/      # 페이지 단위 컴포넌트 (큰 단위)
 ├── mocks/      # 개발용 Mock 데이터
 ├── providers/  # Context API / State 관리
+├── routes/     # 화면 라우팅 관리
 └── styles/     # 전역 스타일 및 폰트 설정
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-hot-toast": "^2.6.0",
+        "react-router": "^7.13.0",
         "zustand": "^5.0.10"
       },
       "devDependencies": {
@@ -1730,6 +1731,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2906,6 +2920,28 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2976,6 +3012,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-hot-toast": "^2.6.0",
+    "react-router": "^7.13.0",
     "zustand": "^5.0.10"
   },
   "devDependencies": {

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,15 +1,17 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router';
 
-import App from './App.jsx'
+import App from './App.jsx';
 
-import './styles/reset.css'
-import './styles/fonts.css'
-import './styles/index.css'
-
+import './styles/reset.css';
+import './styles/fonts.css';
+import './styles/index.css';
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
-)
+);

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Routes, Route } from 'react-router';
+
+export const index = () => {
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+
+      <Route path="/write" element={<StudyForm />} />
+
+      <Route path="/studies/:studyId" element={<StudyDetail />} />
+
+      <Route path="/studies/:studyId/todayhabits" element={<TodayHabits />} />
+
+      <Route path="/studies/:studyId/todayfocus" element={<TodayFocus />} />
+    </Routes>
+  );
+};

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -5,14 +5,10 @@ export const index = () => {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
-
       <Route path="/write" element={<StudyForm />} />
-
       <Route path="/studies/:studyId" element={<StudyDetail />} />
-
-      <Route path="/studies/:studyId/todayhabits" element={<TodayHabits />} />
-
-      <Route path="/studies/:studyId/todayfocus" element={<TodayFocus />} />
+      <Route path="/studies/:studyId/habits" element={<TodayHabits />} />
+      <Route path="/studies/:studyId/focus" element={<TodayFocus />} />
     </Routes>
   );
 };


### PR DESCRIPTION
## 🔧 작업 내용
- [x] react-router 라이브러리 추가
- [x] 페이지 별 라우팅 나눠놓기
- [x] main.jsx에 BrowserRouter 추가. 
- [x] 라우터 폴더가 추가되면서 readme파일도 수정해놨습니다.

### ✚ 기본 폴더구조 추가 필요
- page 폴더에 
Home / StudyForm / StudyDetail / TodayHabits / TodayFocus 폴더 나누기


## 📦패키지 설치
react-router 추가
